### PR TITLE
Fix: Product table migrations

### DIFF
--- a/db/migrate/20180817135401_create_products.rb
+++ b/db/migrate/20180817135401_create_products.rb
@@ -4,7 +4,6 @@ class CreateProducts < ActiveRecord::Migration[5.2]
       t.string :name
       t.text :description
       t.string :image_url
-      t.float :price
       t.timestamps
     end
   end

--- a/db/migrate/20180824125823_add_color_to_products.rb
+++ b/db/migrate/20180824125823_add_color_to_products.rb
@@ -1,5 +1,5 @@
 class AddColorToProducts < ActiveRecord::Migration[5.2]
   def change
-    add_column :products, :color, :string, :price
+    add_column :products, :color, :string  
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,8 +31,15 @@ ActiveRecord::Schema.define(version: 2018_11_02_110811) do
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
-# Could not dump table "products" because of following StandardError
-#   Unknown type 'String' for column 'price'
+  create_table "products", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.string "image_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "color"
+    t.float "price"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"


### PR DESCRIPTION
1. Fixes a migration which has `:price` added.
2. Removes `price` column from create table migration as we have existing migration which adds it